### PR TITLE
Usability patch (2.8.1)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ repositories {
     mavenCentral()
 }
 
-version = System.getenv().getOrDefault("VERSION", "2.8.0")
+version = System.getenv().getOrDefault("VERSION", "2.8.1")
 
 dependencies {
     implementation(group = "com.fasterxml.jackson.core", name = "jackson-core", version = "2.11.1")

--- a/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
+++ b/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
@@ -183,7 +183,7 @@ public class FlintGradlePlugin implements Plugin<Project> {
       }
     }
 
-    FlintResolutionStrategy.getInstance().forceResolutionStrategy(project);
+    FlintResolutionStrategy.getInstance().forceResolutionStrategy(project, extension);
 
     project.getRepositories().maven(repo -> {
       repo.setName("Mojang");

--- a/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
+++ b/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
@@ -154,10 +154,7 @@ public class FlintGradlePlugin implements Plugin<Project> {
 
     this.manifestConfigurator = new ManifestConfigurator(this);
     interaction.setup();
-    project.afterEvaluate((p) -> {
-      extension.ensureConfigured();
-      FlintResolutionStrategy.getInstance().forceResolutionStrategy(p);
-    });
+    project.afterEvaluate((p) -> extension.ensureConfigured());
   }
 
   /**
@@ -178,6 +175,8 @@ public class FlintGradlePlugin implements Plugin<Project> {
             project, staticFileDescription.getTarget(), staticFileDescription.getSourceFile());
       }
     }
+
+    FlintResolutionStrategy.getInstance().forceResolutionStrategy(project);
 
     project.getRepositories().maven(repo -> {
       repo.setName("Mojang");

--- a/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
+++ b/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
@@ -44,11 +44,14 @@ import net.flintmc.gradle.minecraft.MinecraftRepository;
 import net.flintmc.gradle.minecraft.data.environment.EnvironmentType;
 import net.flintmc.gradle.minecraft.data.environment.MinecraftVersion;
 import net.flintmc.gradle.minecraft.yggdrasil.YggdrasilAuthenticator;
+import net.flintmc.gradle.util.JavaClosure;
+import net.flintmc.gradle.util.Util;
 import okhttp3.OkHttpClient;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.invocation.Gradle;
+import org.gradle.api.tasks.Delete;
 
 public class FlintGradlePlugin implements Plugin<Project> {
   public static final String MINECRAFT_TASK_GROUP = "minecraft";
@@ -139,6 +142,7 @@ public class FlintGradlePlugin implements Plugin<Project> {
       } catch (IOException e) {
         throw new UncheckedIOException("Failed to setup artifact URL cache", e);
       }
+
     } else {
       this.httpClient = parentPlugin.httpClient;
       this.downloader = parentPlugin.downloader;
@@ -154,6 +158,9 @@ public class FlintGradlePlugin implements Plugin<Project> {
 
     this.manifestConfigurator = new ManifestConfigurator(this);
     interaction.setup();
+    project.getTasks().getByName("clean").configure(
+        JavaClosure.of((Delete task) -> task.delete(Util.getProjectCacheDir(project))));
+
     project.afterEvaluate((p) -> extension.ensureConfigured());
   }
 

--- a/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
+++ b/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
@@ -171,6 +171,7 @@ public class FlintGradlePlugin implements Plugin<Project> {
     project.getRepositories().maven(repo -> {
       repo.setName("Flint");
       repo.setUrl(FLINT_MAVEN);
+      Util.applyDistributorCredentials(project, repo, false);
     });
 
     project.getRepositories().maven((repo) -> {

--- a/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
+++ b/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
@@ -58,7 +58,6 @@ public class FlintGradlePlugin implements Plugin<Project> {
 
   private static final String MINECRAFT_MAVEN = "https://libraries.minecraft.net";
   private static final String MAVEN_CENTRAL = "https://repo.maven.apache.org/maven2/";
-  private static final String FLINT_MAVEN = "https://dist.labymod.net/api/v1/maven/release/";
 
   private Project project;
 
@@ -67,7 +66,6 @@ public class FlintGradlePlugin implements Plugin<Project> {
   private MavenArtifactURLCache mavenArtifactURLCache;
 
   private FlintGradleExtension extension;
-  private FlintPatcherExtension patcherExtension;
   private JavaPluginInteraction interaction;
   private MinecraftRepository minecraftRepository;
   private SimpleMavenRepository internalRepository;
@@ -108,7 +106,7 @@ public class FlintGradlePlugin implements Plugin<Project> {
       }
 
       this.extension = project.getExtensions().create(FlintGradleExtension.NAME, FlintGradleExtension.class, this);
-      this.patcherExtension = project.getExtensions().create(FlintPatcherExtension.NAME, FlintPatcherExtension.class, this);
+      project.getExtensions().create(FlintPatcherExtension.NAME, FlintPatcherExtension.class, this);
 
       Path flintGradlePath = gradle.getGradleUserHomeDir().toPath().resolve("caches/flint-gradle");
       Path minecraftCache = flintGradlePath.resolve("minecraft-cache");
@@ -170,7 +168,7 @@ public class FlintGradlePlugin implements Plugin<Project> {
 
     project.getRepositories().maven(repo -> {
       repo.setName("Flint");
-      repo.setUrl(FLINT_MAVEN);
+      repo.setUrl(Util.getDistributorMavenURI(project));
       Util.applyDistributorCredentials(project, repo, false);
     });
 
@@ -305,10 +303,6 @@ public class FlintGradlePlugin implements Plugin<Project> {
    */
   public MavenArtifactURLCache getMavenArtifactURLCache() {
     return mavenArtifactURLCache;
-  }
-
-  public FlintPatcherExtension getPatcherExtension() {
-    return patcherExtension;
   }
 
   public Project getProject() {

--- a/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
+++ b/src/main/java/net/flintmc/gradle/FlintGradlePlugin.java
@@ -162,6 +162,21 @@ public class FlintGradlePlugin implements Plugin<Project> {
         JavaClosure.of((Delete task) -> task.delete(Util.getProjectCacheDir(project))));
 
     project.afterEvaluate((p) -> extension.ensureConfigured());
+
+    project.getRepositories().maven(repo -> {
+      repo.setName("Mojang");
+      repo.setUrl(MINECRAFT_MAVEN);
+    });
+
+    project.getRepositories().maven(repo -> {
+      repo.setName("Flint");
+      repo.setUrl(FLINT_MAVEN);
+    });
+
+    project.getRepositories().maven((repo) -> {
+      repo.setName("Internal minecraft");
+      repo.setUrl(minecraftRepository.getBaseDir());
+    });
   }
 
   /**
@@ -184,21 +199,6 @@ public class FlintGradlePlugin implements Plugin<Project> {
     }
 
     FlintResolutionStrategy.getInstance().forceResolutionStrategy(project, extension);
-
-    project.getRepositories().maven(repo -> {
-      repo.setName("Mojang");
-      repo.setUrl(MINECRAFT_MAVEN);
-    });
-
-    project.getRepositories().maven(repo -> {
-      repo.setName("Flint");
-      repo.setUrl(FLINT_MAVEN);
-    });
-
-    project.getRepositories().maven((repo) -> {
-      repo.setName("Internal minecraft");
-      repo.setUrl(minecraftRepository.getBaseDir());
-    });
 
     for (Project subProject : project.getSubprojects()) {
       if (!extension.getProjectFilter().test(subProject)) {

--- a/src/main/java/net/flintmc/gradle/manifest/ManifestConfigurator.java
+++ b/src/main/java/net/flintmc/gradle/manifest/ManifestConfigurator.java
@@ -60,7 +60,6 @@ public class ManifestConfigurator {
   }
 
   private URI projectPublishURI;
-  private URI distributorMavenURI;
   private URI projectMavenURI;
 
   /**
@@ -78,7 +77,7 @@ public class ManifestConfigurator {
       PublishingExtension publishingExtension = project.getExtensions().findByType(PublishingExtension.class);
 
       // Build the distributor URL in form of <host>/maven/<channel>
-      URI distributorUrl = getDistributorMavenURI(
+      URI distributorUrl = Util.getDistributorMavenURI(project,
           "Set enablePublishing to false in the flint extension",
           "Set shouldAutoConfigurePublishing to false in the flint extension");
 
@@ -230,26 +229,6 @@ public class ManifestConfigurator {
   }
 
   /**
-   * Retrieves the base URI of the distributor repository.
-   *
-   * @param notAvailableSolution Messages to display as a solution in case URI can't be computed
-   * @return The base URI of the distributor repository
-   */
-  public URI getDistributorMavenURI(String... notAvailableSolution) {
-    if(distributorMavenURI == null) {
-      distributorMavenURI = Util.concatURI(
-          FlintPluginProperties.DISTRIBUTOR_URL
-              .require(project, notAvailableSolution),
-          "api/v1/maven",
-          FlintPluginProperties.DISTRIBUTOR_CHANNEL
-              .require(project, notAvailableSolution)
-      );
-    }
-
-    return distributorMavenURI;
-  }
-
-  /**
    * Retrieves the base URI of the distributor repository including the project namespace.
    *
    * @param notAvailableSolution Messages to display as a solution in case the URI can't be computed
@@ -257,7 +236,7 @@ public class ManifestConfigurator {
    */
   public URI getProjectMavenURI(String... notAvailableSolution) {
     if(projectMavenURI == null) {
-      URI distributorURI = getDistributorMavenURI(notAvailableSolution);
+      URI distributorURI = Util.getDistributorMavenURI(project, notAvailableSolution);
 
       projectMavenURI = Util.concatURI(
           distributorURI,

--- a/src/main/java/net/flintmc/gradle/manifest/ManifestConfigurator.java
+++ b/src/main/java/net/flintmc/gradle/manifest/ManifestConfigurator.java
@@ -27,7 +27,6 @@ import net.flintmc.gradle.manifest.data.ManifestRepositoryInput;
 import net.flintmc.gradle.manifest.data.ManifestStaticFileInput;
 import net.flintmc.gradle.manifest.tasks.*;
 import net.flintmc.gradle.maven.cache.MavenArtifactURLCache;
-import net.flintmc.gradle.minecraft.InstallStaticFilesTask;
 import net.flintmc.gradle.property.FlintPluginProperties;
 import net.flintmc.gradle.util.MaybeNull;
 import net.flintmc.gradle.util.Util;
@@ -100,18 +99,8 @@ public class ManifestConfigurator {
             publishingExtension.getRepositories().maven((repo) -> repo.setName("FlintDistributor"));
         repository.setUrl(distributorUrl);
 
-        // Try to retrieve authentication, it might not be available
-        HttpHeaderCredentials values = Util.getPublishCredentials(project, false);
-
-        if(values != null) {
-          // Gradle does not allow setting the credentials instance directly, so copy it
-          HttpHeaderCredentials credentials = repository.getCredentials(HttpHeaderCredentials.class);
-          credentials.setName(values.getName());
-          credentials.setValue(values.getValue());
-        }
-
-        // Set the authentication, no further configuration required
-        repository.getAuthentication().create("header", HttpHeaderAuthentication.class);
+        // Apply the access credentials if available
+        Util.applyDistributorCredentials(project, repository, false);
       }
     }
 

--- a/src/main/java/net/flintmc/gradle/manifest/tasks/PublishTaskBase.java
+++ b/src/main/java/net/flintmc/gradle/manifest/tasks/PublishTaskBase.java
@@ -67,7 +67,7 @@ public abstract class PublishTaskBase extends DefaultTask {
         .put(requestBody);
 
 
-    HttpHeaderCredentials credentials = Util.getPublishCredentials(
+    HttpHeaderCredentials credentials = Util.getDistributorCredentials(
         getProject(),
         true,
         "Set enablePublishing to false in the flint extension");

--- a/src/main/java/net/flintmc/gradle/patch/context/LocalPatchContextProvider.java
+++ b/src/main/java/net/flintmc/gradle/patch/context/LocalPatchContextProvider.java
@@ -125,7 +125,7 @@ public class LocalPatchContextProvider implements PatchContextProvider {
       if (patch.getHunks().length == 0) {
         patch.getTargetFile().delete();
       } else {
-        byte[] content = Util.deserializeLines(patch.getHunks()[0].lines);
+        byte[] content = Util.decodeBase64Lines(patch.getHunks()[0].lines);
         this.copyStreamsCloseAll(
             new FileOutputStream(patch.getTargetFile()), new ByteArrayInputStream(content));
       }

--- a/src/main/java/net/flintmc/gradle/patch/context/ZipPatchContextProvider.java
+++ b/src/main/java/net/flintmc/gradle/patch/context/ZipPatchContextProvider.java
@@ -92,7 +92,7 @@ public class ZipPatchContextProvider implements PatchContextProvider {
       this.delete.remove(patch.getTargetPath());
 
       if (patch.isBinary()) {
-        this.binary.put(patch.getTargetPath(), Util.deserializeLines(patch.getHunks()[0].lines));
+        this.binary.put(patch.getTargetPath(), Util.decodeBase64Lines(patch.getHunks()[0].lines));
         this.modified.remove(patch.getTargetPath());
       } else {
 

--- a/src/main/java/net/flintmc/gradle/util/Util.java
+++ b/src/main/java/net/flintmc/gradle/util/Util.java
@@ -540,14 +540,30 @@ public class Util {
   }
 
   /**
-   * Hashes a given byte array and writes it as an hex string
+   * Hashes a given byte array and writes it as a hex string
    *
    * @param data the data to convert
    * @return the md5 hash as a hex string
    */
   public static String md5Hex(byte[] data) {
     try {
-      return new BigInteger(1, MessageDigest.getInstance("MD5").digest(data)).toString(16);
+      MessageDigest digest = MessageDigest.getInstance("MD5");
+      byte[] md5sum = digest.digest(data);
+
+      // Build a hexadecimal string from the md5sum
+      StringBuilder buffer = new StringBuilder();
+      for(byte b : md5sum) {
+        String hex = Integer.toHexString(b & 0xFF);
+
+        if(hex.length() < 2) {
+          // Insert a 0 if the string is too short
+          buffer.append('0');
+        }
+
+        buffer.append(hex);
+      }
+
+      return buffer.toString();
     } catch(NoSuchAlgorithmException e) {
       throw new IllegalStateException("MD5 digest not available");
     }

--- a/src/main/java/net/flintmc/gradle/util/Util.java
+++ b/src/main/java/net/flintmc/gradle/util/Util.java
@@ -388,7 +388,7 @@ public class Util {
    * @throws IOException If an I/O error occurs
    */
   public static boolean isPackageJar(File file) throws IOException {
-    if (file.getName().endsWith(".jar")) {
+    if (!file.getName().endsWith(".jar")) {
       // Needs to be a jar file
       return false;
     }
@@ -407,7 +407,7 @@ public class Util {
    * @throws JsonConverterException If the {@code manifest.json} can't be read as a {@link PackageModel}
    */
   public static PackageModel getPackageModelFromJar(File file) throws IOException, JsonConverterException {
-    if (file.getName().endsWith(".jar")) {
+    if (!file.getName().endsWith(".jar")) {
       // Needs to be a jar file
       return null;
     }

--- a/src/main/java/net/flintmc/gradle/util/Util.java
+++ b/src/main/java/net/flintmc/gradle/util/Util.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.util.Base64;
+import java.util.*;
 import java.util.zip.ZipOutputStream;
 import net.flintmc.gradle.json.JsonConverter;
 import net.flintmc.gradle.json.JsonConverterException;
@@ -59,12 +59,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
@@ -605,14 +599,22 @@ public class Util {
     }
   }
 
-  public static byte[] deserializeLines(List<String> lines) throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+  /**
+   * Decodes a collection of base64 encoded lines into a byte array.
+   *
+   * @param lines The lines to decode
+   * @return The decoded data
+   * @throws IOException If an I/O error occurs while decoding the data
+   */
+  public static byte[] decodeBase64Lines(Collection<String> lines) throws IOException {
+    try(ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
 
-    for (String line : lines) {
-      byteArrayOutputStream.write(Base64.getDecoder().decode(line));
+      for(String line : lines) {
+        byteArrayOutputStream.write(Base64.getDecoder().decode(line));
+      }
+
+      return byteArrayOutputStream.toByteArray();
     }
-
-    return byteArrayOutputStream.toByteArray();
   }
 
   /**
@@ -623,6 +625,6 @@ public class Util {
   public static boolean is64Bit() {
     return System.getProperty("os.name").contains("Windows")
         ? System.getenv("ProgramFiles(x86)") != null
-        : System.getProperty("os.arch").indexOf("64") != -1;
+        : System.getProperty("os.arch").contains("64");
   }
 }

--- a/src/main/java/net/flintmc/gradle/util/Util.java
+++ b/src/main/java/net/flintmc/gradle/util/Util.java
@@ -650,4 +650,21 @@ public class Util {
         ? System.getenv("ProgramFiles(x86)") != null
         : System.getProperty("os.arch").contains("64");
   }
+
+  /**
+   * Retrieves the base URI of the distributor repository.
+   *
+   * @param project The project to use for resolving the properties
+   * @param notAvailableSolution Messages to display as a solution in case URI can't be computed
+   * @return The base URI of the distributor repository
+   */
+  public static URI getDistributorMavenURI(Project project, String... notAvailableSolution) {
+    return concatURI(
+        FlintPluginProperties.DISTRIBUTOR_URL
+            .require(project, notAvailableSolution),
+        "api/v1/maven",
+        FlintPluginProperties.DISTRIBUTOR_CHANNEL
+            .require(project, notAvailableSolution)
+    );
+  }
 }


### PR DESCRIPTION
This PR increases the usability of the Plugin by fixing the correct configuration of the Distributor repository (including credentials and taking the URL from the project properties) as well as fixing 2 bugs preventing Manifest generation from working properly.

From now on the plugin also forces a common version for all dependencies in the `net.flintmc` group.